### PR TITLE
Foursquare: auth using our own client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/golangci-lint*
 /db
+/.env

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/pardot/oidc v0.0.0-20200518180338-f8645300dfbf
 	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 )

--- a/web.go
+++ b/web.go
@@ -1,18 +1,47 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
+
+	"golang.org/x/oauth2"
 )
 
 // the world wide web
 type web struct {
 	monce sync.Once
 	mux   *http.ServeMux
+
+	smgr *secretsManager
+
+	fsqOauthConfig oauth2.Config
 }
 
 func (w *web) index(rw http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.Error(rw, "Not Found", http.StatusNotFound)
+		return
+	}
+}
 
+func (w *web) connect(rw http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(rw, `<a href="%s">Connect Foursquare</a>`, w.fsqOauthConfig.AuthCodeURL("STATE"))
+}
+
+func (w *web) fsqcallback(rw http.ResponseWriter, r *http.Request) {
+	tok, err := w.fsqOauthConfig.Exchange(r.Context(), r.FormValue("code"))
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.smgr.secrets.FourquareAPIKey = tok.AccessToken
+
+	if err := w.smgr.Save(); err != nil {
+		http.Error(rw, "saving token: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprint(rw, "saved")
 }
 
 func (w *web) init() {
@@ -20,6 +49,9 @@ func (w *web) init() {
 		w.mux = http.NewServeMux()
 
 		w.mux.HandleFunc("/", w.index)
+		w.mux.HandleFunc("/connect", w.connect)
+		w.mux.HandleFunc("/connect/fsqcallback", w.fsqcallback)
+
 	})
 }
 


### PR DESCRIPTION
Rather than a rando glitch, connect to foursquare via a registered app
(registration required). Store the keys in a JSON file. This was chosen over
the DB, because it felt a bit weird tying creds in there.