### PR TITLE
Proxy OwnTracks location to recorder

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -72,6 +73,7 @@ func main() {
 			basicAuth         bool
 			otUsername        string
 			otPassword        string
+			otRecorderURL     string
 			requireSubject    string
 			disable4sqSync    bool
 			disableTripitSync bool
@@ -87,6 +89,7 @@ func main() {
 
 		fs.StringVar(&otUsername, "ot-username", getEnvDefault("OT_PUBLISH_USERNAME", ""), "Username for the owntracks publish endpoint (required)")
 		fs.StringVar(&otPassword, "ot-password", getEnvDefault("OT_PUBLISH_PASSWORD", ""), "Password for the owntracks publish endpoint (required)")
+		fs.StringVar(&otRecorderURL, "ot-recorder-url", "", "Optional owntracks publish endpoint to proxy device locations to")
 
 		fs.StringVar(&ah.Issuer, "auth-issuer", getEnvDefault("AUTH_ISSUER", ""), "OIDC Issuer (required unless auth disabled)")
 		fs.StringVar(&ah.ClientID, "auth-client-id", getEnvDefault("AUTH_CLIENT_ID", ""), "OIDC Client ID (required unless auth disabled)")
@@ -129,6 +132,14 @@ func main() {
 
 		if otPassword == "" {
 			errs = append(errs, "ot-password required")
+		}
+		if otRecorderURL != "" {
+			u, err := url.Parse(otRecorderURL)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("parse flag ot-recorder-url: %v", err))
+			} else {
+				ots.recorderURL = u
+			}
 		}
 
 		if !disableAuth && !basicAuth {

--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func main() {
 				l.Fatalf("validating foursquare sync command: %v", err)
 			}
 			go func() {
-				sync := func() {
+				for {
 					if base.smgr.secrets.FourquareAPIKey == "" {
 						log.Print("No foursquare API key saved, not running")
 						return
@@ -229,15 +229,12 @@ func main() {
 						// for now, bombing out is an easy way to get attention
 						l.Fatalf("error running foursquare sync: %v", err)
 					}
-				}
-				sync()
-				ticker := time.NewTicker(fsqSyncInterval)
-				for {
+
 					select {
 					case <-ctx.Done():
 						return
-					case <-ticker.C:
-						sync()
+					case <-time.After(fsqSyncInterval):
+						continue
 					}
 				}
 			}()
@@ -256,7 +253,7 @@ func main() {
 			}
 
 			go func() {
-				sync := func() {
+				for {
 					if tpsync.smgr.secrets.TripitOAuthToken == "" || tpsync.smgr.secrets.TripitOAuthSecret == "" {
 						log.Print("No tripit API keys saved, not running")
 						return
@@ -265,15 +262,12 @@ func main() {
 					if err := tpsync.run(ctx); err != nil {
 						l.Fatalf("error running tripit sync: %v", err)
 					}
-				}
-				sync()
-				ticker := time.NewTicker(tpSyncInterval)
-				for {
+
 					select {
 					case <-ctx.Done():
 						return
-					case <-ticker.C:
-						sync()
+					case <-time.After(tpSyncInterval):
+						continue
 					}
 				}
 			}()

--- a/owntracks.go
+++ b/owntracks.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/url"
+	"strings"
 )
 
 type owntracksStore interface {
@@ -20,6 +24,9 @@ type owntracksServer struct {
 	log logger
 
 	store owntracksStore
+
+	// If this is set, proxy the location.
+	recorderURL *url.URL
 }
 
 func (o *owntracksServer) HandlePublish(w http.ResponseWriter, r *http.Request) {
@@ -30,23 +37,89 @@ func (o *owntracksServer) HandlePublish(w http.ResponseWriter, r *http.Request) 
 
 	// parse message
 	msg := owntracksMessage{}
-	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+	rawMsg, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		o.log.Printf("read owntracks message: %v", err)
+		http.Error(w, fmt.Sprintf("read owntracks message: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if err := json.Unmarshal(rawMsg, &msg); err != nil {
 		o.log.Printf("decoding owntracks message: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// ignore if not location
-	if msg.IsLocation() {
-		if err := o.store.AddOTLocation(r.Context(), msg); err != nil {
-			o.log.Printf("saving owntracks location: %v", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+	if !msg.IsLocation() {
+		o.log.Printf("ignoring payload type %s", msg.Type)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+		return
+	}
+
+	var errs []string
+
+	if err := o.store.AddOTLocation(r.Context(), msg); err != nil {
+		errs = append(errs, fmt.Sprintf("saving owntracks location: %v", err))
+	}
+
+	if o.recorderURL != nil {
+		if err := o.proxyLocation(r, rawMsg); err != nil {
+			errs = append(errs, fmt.Sprintf("proxy owntracks location: %v", err))
 		}
+	}
+
+	// Failed to save location in local database and/or proxy it to recorder.
+	if len(errs) != 0 {
+		http.Error(w, fmt.Sprintf("error: %s", strings.Join(errs, ", ")), http.StatusInternalServerError)
+		return
 	}
 
 	// return empty json array. Eventually we should support reading/publishing
 	// from a MQTT endpoint
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprint(w, `[]`)
+}
+
+func (o *owntracksServer) proxyLocation(req *http.Request, msg []byte) error {
+	// Set user and device params:
+	// https://owntracks.org/booklet/tech/http/
+	// Order of precedence: recorderURL params, request headers, request params.
+	q := o.recorderURL.Query()
+	user, device := q.Get("u"), q.Get("d")
+	if user == "" {
+		user = req.Header.Get("X-Limit-U")
+	}
+	if device == "" {
+		device = req.Header.Get("X-Limit-D")
+	}
+	if user == "" {
+		user = req.URL.Query().Get("u")
+	}
+	if device == "" {
+		device = req.URL.Query().Get("d")
+	}
+
+	proxyURL := *o.recorderURL
+	pq := proxyURL.Query()
+	pq.Set("u", user)
+	pq.Set("d", device)
+	proxyURL.RawQuery = pq.Encode()
+
+	resp, err := http.Post(proxyURL.String(), "application/json", bytes.NewReader(msg))
+	if err != nil {
+		return fmt.Errorf("http post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		o.log.Printf("successfully proxied owntracks location for user %s, device %s", user, device)
+		return nil
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("upstream status %d, body %v", resp.StatusCode, err)
+	}
+	return fmt.Errorf("upstream status %d, body %s", resp.StatusCode, string(body))
 }

--- a/sql.go
+++ b/sql.go
@@ -336,6 +336,9 @@ func newStorage(ctx context.Context, logger logger, connStr string) (*Storage, e
 }
 
 func (s *Storage) migrate(ctx context.Context) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	if _, err := s.db.ExecContext(
 		ctx,
 		`create table if not exists migrations (

--- a/sql.go
+++ b/sql.go
@@ -319,6 +319,10 @@ func newStorage(ctx context.Context, logger logger, connStr string) (*Storage, e
 		return nil, fmt.Errorf("opening DB: %v", err)
 	}
 
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("ping database: %v", err)
+	}
+
 	s := &Storage{
 		db:  db,
 		log: logger,


### PR DESCRIPTION
Add the option to "proxy" location data posted to the OwnTracks endpoint to https://github.com/owntracks/recorder (or another wherewasi instance :brain:)

This way the data is saved in the wherewasi database where it's easy to query etc and can also be visualised in https://github.com/owntracks/frontend.

Eventually it'd be nice to implement the API used by the frontend in wherewasi, and ditch the recorder altogether.

Related: https://github.com/sr/repo/commit/17a835702412cc873f9d87b2075b3c86f8c8dee1

Script to import wherewasi device location into a recorder:
https://github.com/sr/repo/blob/c301a40b17e12f4f5dd48cb7674a1aaa5b6f3de2/src/aux1/cmd/import-wwi-devloc/main.go