### PR TITLE
Error handling fixups

### DIFF
--- a/main.go
+++ b/main.go
@@ -513,7 +513,7 @@ func (b *baseCommand) Parse(ctx context.Context, logger logger) {
 		os.Exit(1)
 	}
 
-	st, err := newStorage(ctx, logger, fmt.Sprintf("file:%s?_foreign_keys=on", filepath.Join(b.dbPath, mainDBFile)))
+	st, err := newStorage(ctx, logger, fmt.Sprintf("file:%s?cache=shared&_foreign_keys=on", filepath.Join(b.dbPath, mainDBFile)))
 	if err != nil {
 		logger.Fatalf("creating storage: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -513,7 +513,7 @@ func (b *baseCommand) Parse(ctx context.Context, logger logger) {
 		os.Exit(1)
 	}
 
-	st, err := newStorage(ctx, logger, fmt.Sprintf("file:%s?cache=shared&_foreign_keys=on", filepath.Join(b.dbPath, mainDBFile)))
+	st, err := newStorage(ctx, logger, fmt.Sprintf("file:%s?_foreign_keys=on", filepath.Join(b.dbPath, mainDBFile)))
 	if err != nil {
 		logger.Fatalf("creating storage: %v", err)
 	}

--- a/owntracks.go
+++ b/owntracks.go
@@ -74,6 +74,7 @@ func (o *owntracksServer) HandlePublish(w http.ResponseWriter, r *http.Request) 
 	// Failed to save location in local database and/or proxy it to recorder.
 	if len(errs) != 0 {
 		metricOTSubmitErrorCount.Inc()
+		o.log.Printf("persisting device location: %s", strings.Join(errs, ", "))
 		http.Error(w, fmt.Sprintf("error: %s", strings.Join(errs, ", ")), http.StatusInternalServerError)
 		return
 	}

--- a/sql_checkin.go
+++ b/sql_checkin.go
@@ -15,9 +15,6 @@ import (
 // }
 
 func (s *Storage) Upsert4sqCheckin(ctx context.Context, checkin fsqCheckin) (string, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
 	if checkin.ID == "" {
 		return "", fmt.Errorf("checkin has no foursquare ID")
 	}
@@ -46,9 +43,6 @@ where fsq_id=$9`,
 // up-to-date user entries for them. Also denormalizes the checkin with
 // information in to the database record.
 func (s *Storage) Sync4sqUsers(ctx context.Context) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
 	txErr := s.execTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		// run against all checkins
 		rows, err := tx.QueryContext(ctx,
@@ -123,9 +117,6 @@ func (s *Storage) Sync4sqUsers(ctx context.Context) error {
 // Sync4sqVenues finds all foursquare checkins in the DB, and ensures there are
 // up-to-date venue entries for them.
 func (s *Storage) Sync4sqVenues(ctx context.Context) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
 	txErr := s.execTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		// run against all checkins
 		rows, err := tx.QueryContext(ctx,

--- a/sql_device_locations.go
+++ b/sql_device_locations.go
@@ -12,9 +12,6 @@ import (
 var _ owntracksStore = (*Storage)(nil)
 
 func (s *Storage) AddOTLocation(ctx context.Context, msg owntracksMessage) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
 	if !msg.IsLocation() {
 		return fmt.Errorf("message needs to be location")
 	}
@@ -45,9 +42,6 @@ func (s *Storage) AddOTLocation(ctx context.Context, msg owntracksMessage) error
 }
 
 func (s *Storage) AddGoogleTakeoutLocations(ctx context.Context, locs []takeoutLocation) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
 	err := s.execTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		for _, loc := range locs {
 			if loc.Raw == nil || len(loc.Raw) < 1 {

--- a/sql_trips.go
+++ b/sql_trips.go
@@ -10,9 +10,6 @@ import (
 )
 
 func (s *Storage) UpsertTripitTrip(ctx context.Context, trip *tripit.Trip, raw []byte) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
 	if trip.Id == "" {
 		return fmt.Errorf("trip has no id")
 	}


### PR DESCRIPTION
* Log the specific error when an error occurs writing an owntracks location to the DB
* more consistent mutex for DB writes, to try and avoid `database table is locked: checkins` errors.