### PR TITLE
Flag in sqlite3_unlock_notify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOPATH=$(shell go env GOPATH)
 
 .PHONY: all $(GOPATH)/bin/wherewasi test lint proto
 
-go_build_flags="-tags=libsqlite3"
+go_build_flags=-tags="libsqlite3 sqlite3_unlock_notify"
 
 all: $(GOPATH)/bin/wherewasi test lint
 

--- a/owntracks.go
+++ b/owntracks.go
@@ -74,6 +74,7 @@ func (o *owntracksServer) HandlePublish(w http.ResponseWriter, r *http.Request) 
 	// Failed to save location in local database and/or proxy it to recorder.
 	if len(errs) != 0 {
 		metricOTSubmitErrorCount.Inc()
+		o.log.Printf("persisting device location: %s", strings.Join(errs, ", "))
 		http.Error(w, fmt.Sprintf("error: %s", strings.Join(errs, ", ")), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
https://sqlite.org/unlock_notify.html
mattn/go-sqlite3#439

Rather than erroring when a table is locked, this should hopefully
make the action just wait