### PR TITLE
Speed up Last4sqCheckinTime and LatestLocationTimestamp

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -301,6 +301,13 @@ var migrations = []migration{
 		);
 		`,
 	},
+	{
+		Idx: 202011221401,
+		SQL: `
+			create index device_locations_timestamp_idx on device_locations(timestamp);
+			create index checkins_checkin_time_idx on checkins(checkin_time);
+		`,
+	},
 }
 
 type Storage struct {

--- a/sql_test.go
+++ b/sql_test.go
@@ -47,7 +47,7 @@ func setupDB(t *testing.T) (ctx context.Context, s *Storage) {
 
 	tr := rand.New(rand.NewSource(time.Now().UnixNano())).Int63()
 
-	connStr := fmt.Sprintf("file:test-%d.db?cache=shared&mode=memory&_foreign_keys=on", tr)
+	connStr := fmt.Sprintf("file:%s/test-%d.db?cache=shared&mode=memory&_foreign_keys=on", t.TempDir(), tr)
 
 	db, err := sql.Open("sqlite3", connStr)
 	if err != nil {


### PR DESCRIPTION
Seeing a lot of these:

```
error gathering metrics: 2 error(s) occurred:
* error collecting metric Desc{fqName: "last_foursquare_checkin_at", help: "Unix time timestamp when the last foursquare checkin was recorded into the DB", constLabels: {}, variableLabels: []}: get latest foursquare checkin timestamp: finding latest checkin: context deadline exceeded
* error collecting metric Desc{fqName: "last_device_location_at", help: "Unix timestamp when of the last device location reported", constLabels: {}, variableLabels: []}: get latest device location timestamp: finding lastest device_locations timestamp: context deadline exceeded
```

This adds indices to speed up the two queries.

Also while here, fix the `setupDB` test helper to stop leaving files in the working directory. 