### PR TITLE
Fix DB lock errors, clean up build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOPATH=$(shell go env GOPATH)
 
 .PHONY: all $(GOPATH)/bin/wherewasi test lint proto
 
-go_build_flags=-tags="libsqlite3 sqlite3_unlock_notify"
+go_build_flags=
 
 all: $(GOPATH)/bin/wherewasi test lint
 

--- a/main.go
+++ b/main.go
@@ -516,7 +516,7 @@ func (b *baseCommand) Parse(ctx context.Context, logger logger) {
 		os.Exit(1)
 	}
 
-	st, err := newStorage(ctx, logger, fmt.Sprintf("file:%s?cache=shared&_foreign_keys=on", filepath.Join(b.dbPath, mainDBFile)))
+	st, err := newStorage(ctx, logger, connStr(filepath.Join(b.dbPath, mainDBFile)))
 	if err != nil {
 		logger.Fatalf("creating storage: %v", err)
 	}
@@ -602,4 +602,8 @@ func (s *secretsManager) Save() error {
 		return fmt.Errorf("writing secrets to %s: %v", s.path, err)
 	}
 	return nil
+}
+
+func connStr(path string) string {
+	return fmt.Sprintf("file:%s?_busy_timeout=5000&_foreign_keys=on", path)
 }

--- a/sql.go
+++ b/sql.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -312,12 +311,6 @@ var migrations = []migration{
 
 type Storage struct {
 	db *sql.DB
-
-	// sqlite supports either one writer, or multiple readers. wrap tables in
-	// our own synchronization to handle this.
-	deviceLocationsMu sync.RWMutex
-	checkinsMu        sync.RWMutex
-	tripsMu           sync.RWMutex
 
 	log logger
 }

--- a/sql_checkin.go
+++ b/sql_checkin.go
@@ -16,8 +16,8 @@ import (
 // }
 
 func (s *Storage) Upsert4sqCheckin(ctx context.Context, checkin fsqCheckin) (string, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.checkinsMu.Lock()
+	defer s.checkinsMu.Unlock()
 
 	if checkin.ID == "" {
 		return "", fmt.Errorf("checkin has no foursquare ID")
@@ -47,8 +47,8 @@ where fsq_id=$9`,
 // up-to-date user entries for them. Also denormalizes the checkin with
 // information in to the database record.
 func (s *Storage) Sync4sqUsers(ctx context.Context) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.checkinsMu.Lock()
+	defer s.checkinsMu.Unlock()
 
 	txErr := s.execTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		// run against all checkins
@@ -124,8 +124,8 @@ func (s *Storage) Sync4sqUsers(ctx context.Context) error {
 // Sync4sqVenues finds all foursquare checkins in the DB, and ensures there are
 // up-to-date venue entries for them.
 func (s *Storage) Sync4sqVenues(ctx context.Context) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.checkinsMu.Lock()
+	defer s.checkinsMu.Unlock()
 
 	txErr := s.execTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		// run against all checkins
@@ -198,6 +198,9 @@ func (s *Storage) Sync4sqVenues(ctx context.Context) error {
 }
 
 func (s *Storage) Last4sqCheckinTime(ctx context.Context) (time.Time, error) {
+	s.checkinsMu.RLock()
+	defer s.checkinsMu.RUnlock()
+
 	var latestCheckin *time.Time
 
 	err := s.db.QueryRowContext(ctx, `select checkin_time from checkins order by datetime(checkin_time) desc limit 1`).Scan(&latestCheckin)
@@ -224,6 +227,9 @@ type Checkin struct {
 }
 
 func (s *Storage) GetCheckins(ctx context.Context, from, to time.Time) ([]Checkin, error) {
+	s.checkinsMu.RLock()
+	defer s.checkinsMu.RUnlock()
+
 	rows, err := s.db.QueryContext(ctx,
 		`select c.checkin_time, v.name, v.lng, v.lat, group_concat(p.name, ';') from checkins c
 left outer join checkin_people cp on (c.id = cp.checkin_id)

--- a/sql_device_locations.go
+++ b/sql_device_locations.go
@@ -20,9 +20,6 @@ type DeviceLocation struct {
 }
 
 func (s *Storage) AddOTLocation(ctx context.Context, msg owntracksMessage) error {
-	s.deviceLocationsMu.Lock()
-	defer s.deviceLocationsMu.Unlock()
-
 	if !msg.IsLocation() {
 		return fmt.Errorf("message needs to be location")
 	}
@@ -53,9 +50,6 @@ func (s *Storage) AddOTLocation(ctx context.Context, msg owntracksMessage) error
 }
 
 func (s *Storage) AddGoogleTakeoutLocations(ctx context.Context, locs []takeoutLocation) error {
-	s.deviceLocationsMu.Lock()
-	defer s.deviceLocationsMu.Unlock()
-
 	err := s.execTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		for _, loc := range locs {
 			if loc.Raw == nil || len(loc.Raw) < 1 {
@@ -99,9 +93,6 @@ func (s *Storage) AddGoogleTakeoutLocations(ctx context.Context, locs []takeoutL
 }
 
 func (s *Storage) RecentLocations(ctx context.Context, from, to time.Time) ([]DeviceLocation, error) {
-	s.deviceLocationsMu.RLock()
-	defer s.deviceLocationsMu.RUnlock()
-
 	rows, err := s.db.QueryContext(ctx,
 		`select lat, lng, accuracy, timestamp, velocity from device_locations where timestamp > ? and timestamp < ? order by timestamp asc`, from, to)
 	if err != nil {
@@ -132,9 +123,6 @@ func (s *Storage) RecentLocations(ctx context.Context, from, to time.Time) ([]De
 // LatestLocationTimestamp returns the time at which the latest location was
 // recorded
 func (s *Storage) LatestLocationTimestamp(ctx context.Context) (time.Time, error) {
-	s.deviceLocationsMu.RLock()
-	defer s.deviceLocationsMu.RUnlock()
-
 	var timestamp time.Time
 
 	if err := s.db.QueryRowContext(ctx, `select timestamp from device_locations order by timestamp desc limit 1`).Scan(&timestamp); err != nil {

--- a/sql_test.go
+++ b/sql_test.go
@@ -133,7 +133,7 @@ func setupDB(t *testing.T) (ctx context.Context, s *Storage) {
 	tr := rand.New(rand.NewSource(time.Now().UnixNano())).Int63()
 	connStr := connStr(fmt.Sprintf("%s/test-%d.db?", t.TempDir(), tr))
 
-	db, err := sql.Open("sqlite3", connStr)
+	db, err := sql.Open("spatialite", connStr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql_test.go
+++ b/sql_test.go
@@ -131,8 +131,7 @@ func setupDB(t *testing.T) (ctx context.Context, s *Storage) {
 	ctx = context.Background()
 
 	tr := rand.New(rand.NewSource(time.Now().UnixNano())).Int63()
-
-	connStr := fmt.Sprintf("file:%s/test-%d.db?cache=shared&_foreign_keys=on", t.TempDir(), tr)
+	connStr := connStr(fmt.Sprintf("%s/test-%d.db?", t.TempDir(), tr))
 
 	db, err := sql.Open("sqlite3", connStr)
 	if err != nil {

--- a/sql_trips.go
+++ b/sql_trips.go
@@ -10,8 +10,8 @@ import (
 )
 
 func (s *Storage) UpsertTripitTrip(ctx context.Context, trip *tripit.Trip, raw []byte) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
+	s.tripsMu.Lock()
+	defer s.tripsMu.Unlock()
 
 	if trip.Id == "" {
 		return fmt.Errorf("trip has no id")
@@ -45,6 +45,9 @@ where tripit_id=?`,
 }
 
 func (s *Storage) LatestTripitID(ctx context.Context) (string, error) {
+	s.tripsMu.RLock()
+	defer s.tripsMu.RUnlock()
+
 	var (
 		tripitID string
 	)

--- a/sql_trips.go
+++ b/sql_trips.go
@@ -10,9 +10,6 @@ import (
 )
 
 func (s *Storage) UpsertTripitTrip(ctx context.Context, trip *tripit.Trip, raw []byte) error {
-	s.tripsMu.Lock()
-	defer s.tripsMu.Unlock()
-
 	if trip.Id == "" {
 		return fmt.Errorf("trip has no id")
 	}
@@ -45,9 +42,6 @@ where tripit_id=?`,
 }
 
 func (s *Storage) LatestTripitID(ctx context.Context) (string, error) {
-	s.tripsMu.RLock()
-	defer s.tripsMu.RUnlock()
-
 	var (
 		tripitID string
 	)


### PR DESCRIPTION
Add a test to make reproducing the concurrency behaviour easier.

Remove shared cache mode. This interacting with how go manages database connections seems to be the cause of our locking errors: https://github.com/mattn/go-sqlite3/issues/632#issue-360437494. Instead, just use a busy timeout and let sqlite figure it out.

Remove sqlite build tags 

* libsqlite3 no longer needed, no more errors on OS X with spatialite using the default config
* unlock_notify didn't fix our errors, now doing concurrency at the app level