### PR TITLE
Embed html template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y sqlite3 libsqlite3-0 libspatialite7 ca-certificates
 
-COPY *.html /app/
-# COPY static/ *.html /app/static/
-
 COPY --from=build /go/bin/wherewasi /usr/bin/
 
 CMD ["/usr/bin/wherewasi"]

--- a/owntracks.go
+++ b/owntracks.go
@@ -41,7 +41,7 @@ func (o *owntracksServer) HandlePublish(w http.ResponseWriter, r *http.Request) 
 		// https://github.com/owntracks/ios/issues/580#issuecomment-495276821).
 		// If we get one of these simply do nothing, as there is nothing to
 		// deserialize and no known action we can take
-		o.log.Printf("skipping publish empty body")
+		o.log.Print("skipping publish empty body")
 		return
 	}
 

--- a/web.go
+++ b/web.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -14,6 +15,12 @@ import (
 	"github.com/ancientlore/go-tripit"
 	geojson "github.com/paulmach/go.geojson"
 	"golang.org/x/oauth2"
+)
+
+var (
+	//go:embed index.tmpl.html
+	indexTmplHtml string
+	indexTmpl     = template.Must(template.New("index.tmpl.html").Parse(indexTmplHtml))
 )
 
 // the world wide web
@@ -180,12 +187,7 @@ func (w *web) index(rw http.ResponseWriter, r *http.Request) {
 		Line: drawLine,
 	}
 
-	t, err := template.ParseFiles("index.tmpl.html")
-	if err != nil {
-		http.Error(rw, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := t.Execute(rw, tmpData); err != nil {
+	if err := indexTmpl.Execute(rw, tmpData); err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Use the new-ish [go:embed](https://pkg.go.dev/embed) stdlib thing to embed the template in the binary. This makes it slightly easier to ship wherewasi as a static binary. I could probably figure out how to make this use the filesystem in development if that's something you care about.