### PR TITLE
main: load secrets from disk if CREDENTIALS_DIRECTORY is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func main() {
 			if ah.Issuer == "" {
 				errs = append(errs, "auth-client-id required")
 			}
-			if ah.Issuer == "" {
+			if ah.ClientSecret == "" {
 				errs = append(errs, "auth-client-secret required")
 			}
 			if ah.Issuer == "" {

--- a/main.go
+++ b/main.go
@@ -131,6 +131,34 @@ func main() {
 			ws.fsqOauthConfig.ClientSecret = v
 		}
 
+		if v, ok := os.LookupEnv("CREDENTIALS_DIRECTORY"); ok {
+			l.Printf("loading credentials from files in directory %s", v)
+
+			if s, err := os.ReadFile(filepath.Join(v, "secure-key")); err == nil {
+				secureKeyFlag = strings.TrimSpace(string(s))
+			}
+			if s, err := os.ReadFile(filepath.Join(v, "ot-publish-password")); err == nil {
+				otPassword = strings.TrimSpace(string(s))
+			}
+			if s, err := os.ReadFile(filepath.Join(v, "auth-client-secret")); err == nil {
+				ah.ClientSecret = strings.TrimSpace(string(s))
+			}
+			if s, err := os.ReadFile(filepath.Join(v, "fsq-client-id")); err == nil {
+				ws.fsqOauthConfig.ClientID = strings.TrimSpace(string(s))
+			}
+			if s, err := os.ReadFile(filepath.Join(v, "fsq-client-secret")); err == nil {
+				ws.fsqOauthConfig.ClientSecret = strings.TrimSpace(string(s))
+			}
+			if s, err := os.ReadFile(filepath.Join(v, "tripit-api-key")); err == nil {
+				ws.tripitAPIKey = strings.TrimSpace(string(s))
+				tpsync.oauthAPIKey = strings.TrimSpace(string(s))
+			}
+			if s, err := os.ReadFile(filepath.Join(v, "tripit-api-secret")); err == nil {
+				ws.tripitAPISecret = strings.TrimSpace(string(s))
+				tpsync.oauthAPISecret = strings.TrimSpace(string(s))
+			}
+		}
+
 		var errs []string
 
 		if secureKeyFlag == "" {
@@ -309,7 +337,6 @@ func main() {
 			}, func(error) {
 				tripitSyncDone <- struct{}{}
 				log.Print("returning tripit shutdown")
-
 			})
 
 		}
@@ -332,7 +359,6 @@ func main() {
 				l.Printf("shutting down main http server: %v", err)
 			}
 			log.Print("returning http shutdown")
-
 		})
 
 		if promListen != "" {
@@ -579,7 +605,7 @@ func (s *secretsManager) Save() error {
 	if err != nil {
 		return fmt.Errorf("marshaling secrets: %s", err)
 	}
-	if err := os.WriteFile(s.path, b, 0600); err != nil {
+	if err := os.WriteFile(s.path, b, 0o600); err != nil {
 		return fmt.Errorf("writing secrets to %s: %v", s.path, err)
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -265,6 +265,13 @@ func main() {
 		}
 
 		if !disableTripitSync {
+			if v := os.Getenv("TRIPIT_API_KEY"); v != "" && ws.tripitAPIKey == "" {
+				ws.tripitAPIKey = v
+			}
+			if v := os.Getenv("TRIPIT_API_SECRET"); v != "" && ws.tripitAPISecret == "" {
+				ws.tripitAPISecret = v
+			}
+
 			if ws.tripitAPIKey == "" || ws.tripitAPISecret == "" {
 				l.Fatal("tripit oauth1 config not set on ws")
 			}

--- a/main_tripitimport.go
+++ b/main_tripitimport.go
@@ -27,8 +27,8 @@ type tripitSyncCommand struct {
 }
 
 func (t *tripitSyncCommand) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&t.oauthAPIKey, "tripit-api-key", getEnvDefault("TRIPIT_API_KEY", ""), "Oauth1 API Key for Tripit")
-	fs.StringVar(&t.oauthAPISecret, "tripit-api-secret", getEnvDefault("TRIPIT_API_SECRET", ""), "Oauth1 API Secret for Tripit")
+	fs.StringVar(&t.oauthAPIKey, "tripit-api-key", "", "Oauth1 API Key for Tripit")
+	fs.StringVar(&t.oauthAPISecret, "tripit-api-secret", "", "Oauth1 API Secret for Tripit")
 }
 
 func (t *tripitSyncCommand) Validate() error {


### PR DESCRIPTION
This adds support for loading secrets passed through via https://systemd.io/CREDENTIALS/, and fixes a couple small flag issues. I am not really sure and have not tested what the exact behaviour is when mixing environment variables, flags, and systemd-creds.