### PR TITLE
Set env secret on tpsync too

### DIFF
--- a/main.go
+++ b/main.go
@@ -323,11 +323,21 @@ func main() {
 		}
 
 		if !disableTripitSync {
-			if v := os.Getenv("TRIPIT_API_KEY"); v != "" && ws.tripitAPIKey == "" {
-				ws.tripitAPIKey = v
+			if v := os.Getenv("TRIPIT_API_KEY"); v != "" {
+				if ws.tripitAPIKey == "" {
+					ws.tripitAPIKey = v
+				}
+				if tpsync.oauthAPIKey == "" {
+					tpsync.oauthAPIKey = v
+				}
 			}
-			if v := os.Getenv("TRIPIT_API_SECRET"); v != "" && ws.tripitAPISecret == "" {
-				ws.tripitAPISecret = v
+			if v := os.Getenv("TRIPIT_API_SECRET"); v != "" {
+				if ws.tripitAPISecret == "" {
+					ws.tripitAPISecret = v
+				}
+				if tpsync.oauthAPISecret == "" {
+					tpsync.oauthAPISecret = v
+				}
 			}
 
 			if ws.tripitAPIKey == "" || ws.tripitAPISecret == "" {


### PR DESCRIPTION
We removed the env default from the flag, but then only set the env var on the web server. This sets it on the tpsync instance too if needed.

The multiple copies of the secret is a bit jank so might refactor it a bit, now is not that time tho.